### PR TITLE
update gemspec to support lita3

### DIFF
--- a/lita-totems.gemspec
+++ b/lita-totems.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-totems"
   spec.version       = "0.1.0"
-  spec.authors       = ["Charles Finkel"]
+  spec.authors       = ["Charles Finkel", "Vijay Ramesh"]
   spec.email         = ["cf@dropbox.com"]
   spec.description   = %q{Totems handler for Lita)}
   spec.summary       = %q{Adds support to Lita for Totems}
@@ -13,13 +13,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 2.4"
+  spec.add_runtime_dependency "lita", ">= 2.4"
   spec.add_runtime_dependency "chronic_duration"
   spec.add_runtime_dependency "redis-semaphore"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 2.14"
+  spec.add_development_dependency "rspec", ">= 3.0.0.beta1"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "coveralls"


### PR DESCRIPTION
looked through the notes at http://www.lita.io/lita-3.0 nothing seemingly needed to be changed beyond updating the gemspec to use rspec 3 and changing the runtime dependency on lita to not lock on version 2.*

thanks Charles!
