### PR TITLE
Add kicking/yielding user's name to kick/yield notifications

### DIFF
--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -183,7 +183,7 @@ module Lita
         redis.srem("user/#{past_owning_user_id}/totems", totem)
         redis.hdel("totem/#{totem}/waiting_since", past_owning_user_id)
         redis.hdel("totem/#{totem}/message", past_owning_user_id)
-        robot.send_messages(Lita::Source.new(user: Lita::User.find_by_id(past_owning_user_id)), %{You have been kicked from totem "#{totem}".})
+        robot.send_messages(Lita::Source.new(user: Lita::User.find_by_id(past_owning_user_id)), %{You have been kicked from totem "#{totem}" by #{response.user.name}.})
         next_user_id = redis.lpop("totem/#{totem}/list")
         if next_user_id
           redis.set("totem/#{totem}/owning_user_id", next_user_id)
@@ -250,7 +250,7 @@ module Lita
           redis.sadd("user/#{next_user_id}/totems", totem)
           redis.hset("totem/#{totem}/waiting_since", next_user_id, Time.now.to_i)
           next_user = Lita::User.find_by_id(next_user_id)
-          robot.send_messages(Lita::Source.new(user: next_user), %{You are now in possession of totem "#{totem}."})
+          robot.send_messages(Lita::Source.new(user: next_user), %{You are now in possession of totem "#{totem}," yielded by #{response.user.name}.})
           response.reply "You have yielded the totem to #{next_user.name}."
         else
           redis.del("totem/#{totem}/owning_user_id")

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -176,7 +176,7 @@ describe Lita::Handlers::Totems, lita_handler: true do
           expect(robot).to receive(:send_messages).twice do |target, message|
             expect([another_user.id, carl.id]).to include(target.user.id)
             if target.user.id == another_user.id
-              expect(message).to eq(%{You are now in possession of totem "chicken."})
+              expect(message).to eq(%{You are now in possession of totem "chicken," yielded by #{carl.name}.})
             elsif target.user.id == carl.id
               expect(message).to eq("You have yielded the totem to #{another_user.name}.")
             end
@@ -362,7 +362,7 @@ describe Lita::Handlers::Totems, lita_handler: true do
             if target.user.id == carl.id
               expect(message).to eq(%{You are now in possession of totem "chicken".})
             elsif target.user.id == another_user.id
-              expect(message).to eq(%{You have been kicked from totem "chicken".})
+              expect(message).to eq(%{You have been kicked from totem "chicken" by #{carl.name}.})
             end
           end
         send_message("totems kick chicken", as: carl)
@@ -377,7 +377,7 @@ describe Lita::Handlers::Totems, lita_handler: true do
         expect(robot).to receive(:send_messages).twice do |target, message|
           expect([another_user.id, carl.id]).to include(target.user.id)
           if target.user.id == carl.id
-            expect(message).to eq(%{You have been kicked from totem "chicken".})
+            expect(message).to eq(%{You have been kicked from totem "chicken" by #{user.name}.})
           elsif target.user.id == another_user.id
             expect(message).to eq("")
           end


### PR DESCRIPTION
@vijaykramesh 

Lets you know who kicked you via message to avoid mystery kicks. Also tells you who has yielded a totem when you come to possess it. 