### PR TITLE
Use different form of emphasis for totem name

### DIFF
--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -197,7 +197,7 @@ module Lita
                         users_cache = new_users_cache
                         r           = "Totems:\n"
                         redis.smembers("totems").each do |totem|
-                          r += "- #{totem}\n"
+                          r += "*#{totem}*\n"
                           r += list_users_print(totem, '  ', users_cache)
                         end
                         r

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -400,18 +400,18 @@ describe Lita::Handlers::Totems, lita_handler: true do
         Timecop.freeze("2014-03-02 13:00:00") do
           send_message("totems info")
           expect(replies.last).to include <<-END
-- chicken
+*chicken*
   1. Carl (held for 1d 1h)
   2. Test User (waiting for 1d 1h)
   3. person_2 (waiting for 1d 1h)
           END
           expect(replies.last).to include <<-END
-- duck
+*duck*
   1. person_2 (held for 1d 1h)
   2. Carl (waiting for 1d 1h)
           END
           expect(replies.last).to include <<-END
-- ball
+*ball*
           END
         end
       end


### PR DESCRIPTION
The `-` prefix is confusing as that is typically reserved for sub-items in a list.

On Slack this will bold the title. Even if you're not on Slack, I think this is still a slight improvement over the existing `-` strategy, but admittedly I would have preferred to make this an option.
